### PR TITLE
CCD-2124: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.50') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,9 +7,4 @@
     <cve>CVE-2021-37137</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2124 (https://tools.hmcts.net/jira/browse/CCD-2124)


### Change description ###
- Updated dependencies section of build.gradle.  Set version of org.apache.tomcat.embed group to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
