### PR TITLE
CVE-2022-24823 : hmc-hmi-outbound-adapter fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.77'
+  netty           : '4.1.77.Final'
 ]
 
 ext['spring-framework.version'] = '5.3.18'

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.74.Final'
+  netty           : '4.1.77'
 ]
 
 ext['spring-framework.version'] = '5.3.18'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -143,11 +143,4 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
     <cve>CVE-2022-22968</cve>
   </suppress>
-
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-      file name: netty-codec-***-4.1.74.Final.jar
-   ]]></notes>
-    <cve>CVE-2022-24823</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3189

netty is upgraded to version 4.1.77.
Netty is an open-source, asynchronous event-driven network application framework. The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
