### PR TITLE
Update to dependencies for CVE Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'idea'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.4.5'
+  id 'org.springframework.boot' version '2.4.9'
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.1.1'
@@ -206,8 +206,8 @@ def versions = [
   netty           : '4.1.77.Final'
 ]
 
-ext['spring-framework.version'] = '5.3.18'
-ext['spring-security.version'] = '5.4.7'
+ext['spring-framework.version'] = '5.3.21'
+ext['spring-security.version'] = '5.7.2'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 
@@ -239,7 +239,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.58') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,97 +4,74 @@
   <!--Please add all the false positives under the below section-->
   <suppress>
     <notes>False Positives
+      List of False Positives: https://github.com/jeremylong/DependencyCheck/issues?q=label%3A%22FP+Report%22
+      Things to note:
+        Update org.owasp.dependencycheck to v7.x.x or remove org.owasp.dependencycheck then
+        update uk.gov.hmcts.java version which introduces dependencycheck v7.x.x
+        Note that updating the uk.gov.hmcts.java pulls in other dependency versions which may have cves assigned
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/HMAN-236
     </notes>
     <cve>CVE-2016-1000027</cve>
-  </suppress>
-  <!--End of false positives section -->
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-243</notes>
+    <cve>CVE-2018-11039</cve>
+    <cve>CVE-2018-1257</cve>
+    <cve>CVE-2020-5421</cve>
+    <cve>CVE-2018-11040</cve>
     <cve>CVE-2013-4152</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-242</notes>
     <cve>CVE-2014-0054</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-244</notes>
+    <cve>CVE-2013-7315</cve>
     <cve>CVE-2013-7315</cve>
   </suppress>
 
   <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/CCD-2926</notes>
+    <notes>
+      <![CDATA[
+        file name: spring-plugin-core-2.0.0.RELEASE.jar
+        file name: spring-plugin-metadata-2.0.0.RELEASE.jar
+      ]]>
+      https://tools.hmcts.net/jira/browse/HMAN-235
+      CVEs are on transitive dependencies of springfox-swagger2 which hasn't been updated in about 2 years
+      CVE-2022-22970 refer https://tools.hmcts.net/jira/browse/HMAN-266
+      CVE-2022-22950 refer https://tools.hmcts.net/jira/browse/HMAN-316
+    </notes>
     <cve>CVE-2022-22965</cve>
-  </suppress>
-
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-235 </notes>
     <cve>CVE-2022-22968</cve>
-  </suppress>
-
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-237</notes>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-247</notes>
-    <cve>CVE-2022-22971</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-247</notes>
     <cve>CVE-2022-22970</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-263</notes>
-    <cve>CVE-2022-22976</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-288</notes>
-    <cve>CVE-2022-22978</cve>
-  </suppress>
-
-  <suppress>
-    <notes></notes>
-    <cve>CVE-2018-11040</cve>
-  </suppress>
-
-  <suppress>
-    <notes></notes>
-    <cve>CVE-2020-5421</cve>
-  </suppress>
-
-  <suppress>
-    <notes></notes>
-    <cve>CVE-2018-1257</cve>
-  </suppress>
-
-  <suppress>
-    <notes></notes>
-    <cve>CVE-2018-11039</cve>
-  </suppress>
-
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-316</notes>
     <cve>CVE-2022-22950</cve>
   </suppress>
 
   <suppress>
-    <notes></notes>
+    <notes>
+      <![CDATA[ file name: tomcat-embed-core-9.0.63.jar]]>
+      FP https://github.com/jeremylong/DependencyCheck/issues/4634
+      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/HMAN-330
+    </notes>
     <cve>CVE-2022-34305</cve>
   </suppress>
 
   <suppress>
-    <notes></notes>
-    <cve>CVE-2022-33915</cve>
+    <notes>
+      <![CDATA[ file name: spring-security-crypto-5.7.2.jar]]>
+      FP https://github.com/jeremylong/DependencyCheck/issues/4629
+    </notes>
+    <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+  </suppress>
+  <!--End of false positives section -->
+
+  <suppress>
+    <notes>
+      <![CDATA[file name: spring-security-rsa-1.0.10.RELEASE.jar]]>
+      CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/HMAN-288
+    </notes>
+    <cve>CVE-2022-22976</cve>
+    <cve>CVE-2022-22978</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: okhttp-3.14.9.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp@.*$</packageUrl>
+    <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-237
https://tools.hmcts.net/jira/browse/HMAN-267
https://tools.hmcts.net/jira/browse/HMAN-242
### Change description ###
- tomcat CVE-2022-29885
- spring updates: CVE-2022-22971
- spring update (>2.4.9) causes integration test to fail
- suppressing: CVE-2020-5408
- suppressions.xml cleanup

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
