### PR TITLE
HMAN-331 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,15 +41,6 @@
 
   <suppress>
     <notes>
-      <![CDATA[ file name: tomcat-embed-core-9.0.63.jar]]>
-      FP https://github.com/jeremylong/DependencyCheck/issues/4634
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/HMAN-330
-    </notes>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-
-  <suppress>
-    <notes>
       <![CDATA[ file name: spring-security-crypto-5.7.2.jar]]>
       FP https://github.com/jeremylong/DependencyCheck/issues/4629
     </notes>
@@ -73,12 +64,12 @@
     <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp@.*$</packageUrl>
     <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
   </suppress>
-  
+
   <suppress>
     <cve>CVE-2022-2047</cve>
     <cve>CVE-2022-2048</cve>
   </suppress>
-  
+
   <suppress>
     <notes>
       https://tools.hmcts.net/jira/browse/HMAN-417


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HMAN-331
CVE-2022-34305 tomcat upgrade 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
