### PR TITLE
HMAN-509 Remove discoveryComposite from health endpoint

### DIFF
--- a/src/functionalTest/resources/features/F-000/S-000.td.json
+++ b/src/functionalTest/resources/features/F-000/S-000.td.json
@@ -27,16 +27,6 @@
     "body" : {
       "status" : "UP",
       "components" : {
-        "discoveryComposite" : {
-          "description" : "Discovery Client not initialized",
-          "status" : "UNKNOWN",
-          "components" : {
-            "discoveryClient" : {
-              "description" : "Discovery Client not initialized",
-              "status" : "UNKNOWN"
-            }
-          }
-        },
         "diskSpace" : {
           "status" : "UP",
           "details" : {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
     name: HMC HMI Outbound Adapter
   jackson:
     property-naming-strategy: SNAKE_CASE
+  cloud:
+    discovery:
+      client:
+        composite-indicator:
+          enabled: false
 #  datasource:
 #    driver-class-name: org.postgresql.Driver
 #    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${DB_OPTIONS:}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-509

### Change description ###
Remove discoveryComposite from health endpoint

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes (tests expecting discoveryComposite from the health endpoint may fail)
[] No
```

