### PR TITLE
HMAN-558 : Fix-CVE-2023-20862-CVE-2023-20863 (bumped version of springframework and springsecurity)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'idea'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.4.9'
+  id 'org.springframework.boot' version '2.7.11'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.1.1'
   id 'uk.gov.hmcts.java' version '0.12.41'
@@ -205,8 +205,8 @@ def versions = [
   netty           : '4.1.86.Final'
 ]
 
-ext['spring-framework.version'] = '5.3.26'
-ext['spring-security.version'] = '5.7.5'
+ext['spring-framework.version'] = '5.3.27'
+ext['spring-security.version'] = '5.7.8'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.33'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'idea'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.11'
+  id 'org.springframework.boot' version '2.4.9'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.1.1'
   id 'uk.gov.hmcts.java' version '0.12.41'

--- a/charts/hmc-hmi-outbound-adapter/Chart.yaml
+++ b/charts/hmc-hmi-outbound-adapter/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
     version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
-    version: 0.4.0
+    version: 1.0.4
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: servicebus.enabled

--- a/charts/hmc-hmi-outbound-adapter/Chart.yaml
+++ b/charts/hmc-hmi-outbound-adapter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for hmc-hmi-outbound-adapter App
 name: hmc-hmi-outbound-adapter
 home: https://github.com/hmcts/hmc-hmi-outbound-adapter
-version: 0.1.10
+version: 0.1.11
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:

--- a/charts/hmc-hmi-outbound-adapter/values.preview.template.yaml
+++ b/charts/hmc-hmi-outbound-adapter/values.preview.template.yaml
@@ -7,10 +7,10 @@ java:
     HMC_SERVICE_BUS_INBOUND_QUEUE: hmc-from-hmi
   secrets:
     HMC_SERVICE_BUS_OUTBOUND_CONNECTION_STRING:
-      secretRef: servicebus-secret-queue-{{ .Release.Name }}-servicebus-hmc-to-hmi
+      secretRef: hmc-sb-preview
       key: connectionString
     HMC_SERVICE_BUS_INBOUND_CONNECTION_STRING:
-      secretRef: servicebus-secret-queue-{{ .Release.Name }}-servicebus-hmc-from-hmi
+      secretRef: hmc-sb-preview
       key: connectionString
   keyVaults:
     hmc:
@@ -21,8 +21,8 @@ java:
 servicebus:
   enabled: true
   teamName: CCD
-  resourceGroup: hmc-aks
-  serviceplan: standard
+  resourceGroup: hmc-aso-preview-rg
+  sbNamespace: hmc-sb-preview
   setup:
     queues:
       - name: hmc-to-hmi

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,17 +3,12 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer [Ticket]
         CVE-2022-1471 refer [Ticket]
-        CVE-2023-20860 refer [Ticket]
-        CVE-2023-20863 refer [Ticket]
-        CVE-2023-20862 refer [Ticket]
-    
         CVE-2023-28709 refer [Ticket]
         CVE-2023-20883 refer [Ticket]
-        CVE-2023-34411 refer [Ticket]</notes>
+        CVE-2023-34411 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-20863</cve>
-    <cve>CVE-2023-20862</cve>
     <cve>CVE-2023-28709</cve>
     <cve>CVE-2023-20883</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-558

### Change description ###

HMAN-558 : Fix-CVE-2023-20862-CVE-2023-20863 (bumped version of springframework and springsecurity)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
