### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,7 @@ def versions = [
   junitPlatform   : '1.7.1',
   lombok          : '1.18.8',
   mapstruct       : '1.4.2.Final',
-  reformLogging   : '5.1.9',
+  reformLogging   : '6.0.1',
   springBoot      : springBoot.class.package.implementationVersion,
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.