### PR TITLE
CCD-4845: rennovate config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "java:gradle"
-    directory: "/"
-    update_schedule: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,19 @@
 {
-  "enabledManagers": ["helm-requirements","gradle-wrapper"],
-  "labels": ["dependencies"],
-  "helm-requirements":
-  {
-    "fileMatch": ["\\Chart.yaml$"],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>hmcts/.github:renovate-config"],
+  "labels": ["Renovate-dependencies"],
+  "major": {
+    "dependencyDashboardApproval": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor", "patch"
+      ],
+      "groupName": "All patch-minor dependencies",
+      "groupSlug": "All-minor-patch",
+      "addLabels": ["Renovate All-minor-patch"],
+      "automerge": false
     }
-  }
+  ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4845

### Change description ###

Renovate config is now mandatory in every repo extending default org level config without using enabledManagers. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```