### PR TITLE
Onboard CVE dashboard intake

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -21,6 +21,7 @@ env.OAUTH2_CLIENT_ID = "ccd_gateway"
 env.OAUTH2_REDIRECT_URI = "https://www-ccd.aat.platform.hmcts.net/oauth2redirect"
 
 withPipeline(type, product, component) {
+  enableCveDashboardIngestion()
   syncBranchesWithMaster(branchesToSync)
   enableAksStagingDeployment()
   disableLegacyDeployment()
@@ -116,5 +117,4 @@ withPipeline(type, product, component) {
         ]
     }
 }
-
 


### PR DESCRIPTION
## Summary
- use the CVE dashboard Jenkins library branch
- enable CVE dashboard ingestion for the CNP pipeline

## Testing
- Not run; Jenkins pipeline configuration only