### PR TITLE
HMAN-1041: Log error message for non-400, 401 or 404 errors

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/repository/FutureHearingRepositoryIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/repository/FutureHearingRepositoryIT.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckActiveDirectoryException
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckException;
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckHmiException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 
 import java.util.List;
 
@@ -113,10 +114,10 @@ public class FutureHearingRepositoryIT extends BaseTest {
         }
 
         @Test
-        void shouldThrow500AuthenticationException() {
+        void shouldThrow500ServerErrorException() {
             stubPostMethodThrowingAuthenticationError(500, GET_TOKEN_URL);
             assertThatThrownBy(defaultFutureHearingRepository::retrieveAuthToken)
-                .isInstanceOf(AuthenticationException.class)
+                .isInstanceOf(ServerErrorException.class)
                 .hasMessageContaining(SERVER_ERROR);
         }
     }
@@ -276,11 +277,11 @@ public class FutureHearingRepositoryIT extends BaseTest {
         }
 
         @Test
-        void shouldThrow500AuthenticationException() {
+        void shouldThrow500ServerErrorException() {
             stubSuccessfullyReturnToken(TOKEN);
             stubPostMethodThrowingAuthenticationError(500, HMI_REQUEST_URL);
             assertThatThrownBy(() -> defaultFutureHearingRepository.createHearingRequest(data, CASE_LISTING_REQUEST_ID))
-                .isInstanceOf(AuthenticationException.class)
+                .isInstanceOf(ServerErrorException.class)
                 .hasMessageContaining(SERVER_ERROR);
         }
     }
@@ -419,13 +420,13 @@ public class FutureHearingRepositoryIT extends BaseTest {
         }
 
         @Test
-        void shouldRethrowAuthenticationExceptionWhen405Error() {
+        void shouldRethrowServerErrorExceptionWhen405Error() {
             stubFailToReturnToken(405, "4000: Failed to get token", List.of(4000));
 
-            AuthenticationException exception =
-                assertThrows(AuthenticationException.class,
+            ServerErrorException exception =
+                assertThrows(ServerErrorException.class,
                              () -> defaultFutureHearingRepository.deleteHearingRequest(data, CASE_LISTING_REQUEST_ID),
-                             "AuthenticationException should be thrown");
+                             "ServerErrorException should be thrown");
 
             ErrorDetails errorDetails = exception.getErrorDetails();
             assertErrorDetails(errorDetails, "4000: Failed to get token", 4000);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/MessageProcessorPendingRequestIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/MessageProcessorPendingRequestIT.java
@@ -270,7 +270,8 @@ class MessageProcessorPendingRequestIT extends BaseTest {
         return Stream.of(
             arguments(400, "AADSTS1002012: The provided value for scope scope is not valid.", List.of(1002012)),
             arguments(401, "AADSTS7000215: Invalid client secret provided.", List.of(7000215)),
-            arguments(404, "AD Resource not found", List.of(1000000))
+            arguments(404, "AD Resource not found", List.of(1000000)),
+            arguments(500, "AD server error", List.of(2000000))
         );
     }
 
@@ -287,10 +288,15 @@ class MessageProcessorPendingRequestIT extends BaseTest {
         resourceNotFoundErrorDetails.setApiStatusCode(404);
         resourceNotFoundErrorDetails.setApiErrorMessage("Resource not found");
 
+        ErrorDetails serverErrorErrorDetails = new ErrorDetails();
+        serverErrorErrorDetails.setErrorCode(500);
+        serverErrorErrorDetails.setErrorDescription("Server error");
+
         return Stream.of(
             arguments(authenticationErrorDetails, 401),
             arguments(badFutureHearingRequestErrorDetails, 400),
-            arguments(resourceNotFoundErrorDetails, 404)
+            arguments(resourceNotFoundErrorDetails, 404),
+            arguments(serverErrorErrorDetails, 500)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImplIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImplIT.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.ApiClientException;
 import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.repository.HearingRepository;
 import uk.gov.hmcts.reform.hmc.repository.HearingStatusAuditRepository;
 import uk.gov.hmcts.reform.hmc.repository.PendingRequestRepository;
@@ -206,23 +207,29 @@ class PendingRequestServiceImplIT extends BaseTest {
         ErrorDetails errorDetailsAuthException = new ErrorDetails();
         errorDetailsAuthException.setAuthErrorCodes(List.of(1000, 2000));
         errorDetailsAuthException.setAuthErrorDescription("auth error description");
-        AuthenticationException authenticationExceptionNonEmptyErrorDetails =
+        final AuthenticationException authenticationExceptionNonEmptyErrorDetails =
             new AuthenticationException("authentication message - non-empty ErrorDetails", errorDetailsAuthException);
 
-        AuthenticationException authenticationExceptionEmptyErrorDetails =
+        final AuthenticationException authenticationExceptionEmptyErrorDetails =
             new AuthenticationException("authentication message - empty ErrorDetails", new ErrorDetails());
 
-        AuthenticationException authenticationExceptionNullErrorDetails =
+        final AuthenticationException authenticationExceptionNullErrorDetails =
             new AuthenticationException("authentication message - null ErrorDetails", null);
 
         ErrorDetails errorDetailsBadFhrException = new ErrorDetails();
         errorDetailsBadFhrException.setErrorCode(401);
         errorDetailsBadFhrException.setErrorDescription("error description");
-        BadFutureHearingRequestException badFutureHearingRequestException =
+        final BadFutureHearingRequestException badFutureHearingRequestException =
             new BadFutureHearingRequestException("bad future hearing request message", errorDetailsBadFhrException);
 
         String errorDescriptionHtml = "<html><head><title>500 Internal Server Error</title></head></html>";
-        ApiClientException apiClientException = new ApiClientException("Server error", 500, errorDescriptionHtml);
+        final ApiClientException apiClientException = new ApiClientException("Server error", 500, errorDescriptionHtml);
+
+        ErrorDetails errorDetailsServerErrorException = new ErrorDetails();
+        errorDetailsServerErrorException.setErrorCode(500);
+        errorDetailsServerErrorException.setErrorDescription("server error description");
+        final ServerErrorException serverErrorException =
+            new ServerErrorException("server error message", 500, errorDetailsServerErrorException);
 
         return Stream.of(
             arguments(named("ResourceNotFoundException", createResourceNotFoundException()),
@@ -261,6 +268,12 @@ class PendingRequestServiceImplIT extends BaseTest {
                       errorDescriptionHtml,
                       "{\"errorCode\":500,\"errorDescription\":\"" + errorDescriptionHtml + "\"}",
                       List.of(createErrorStatusLogMessage(errorDescriptionHtml))
+            ),
+            arguments(named("ServerErrorException", serverErrorException),
+                      500,
+                      "server error description",
+                      "{\"errCode\":500,\"errorDesc\":\"server error description\"}",
+                      List.of(createErrorStatusLogMessage("server error description"))
             ),
             arguments(named("RuntimeException", new RuntimeException("runtime exception")),
                       null,

--- a/src/main/java/uk/gov/hmcts/reform/hmc/client/futurehearing/FutureHearingErrorDecoder.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/client/futurehearing/FutureHearingErrorDecoder.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.ApiClientException;
 import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -64,14 +65,18 @@ public class FutureHearingErrorDecoder implements ErrorDecoder {
         }
 
         switch (response.status()) {
-            case 400:
+            case 400 -> {
                 return new BadFutureHearingRequestException(INVALID_REQUEST, errorDetails);
-            case 401:
+            }
+            case 401 -> {
                 return new AuthenticationException(INVALID_SECRET, errorDetails);
-            case 404:
+            }
+            case 404 -> {
                 return new ResourceNotFoundException(REQUEST_NOT_FOUND);
-            default:
-                return new AuthenticationException(SERVER_ERROR, errorDetails);
+            }
+            default -> {
+                return new ServerErrorException(SERVER_ERROR, response.status(), errorDetails);
+            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/errorhandling/ServerErrorException.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/errorhandling/ServerErrorException.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.hmc.errorhandling;
+
+import lombok.Getter;
+import uk.gov.hmcts.reform.hmc.client.futurehearing.ErrorDetails;
+
+import java.io.Serial;
+
+@Getter
+public class ServerErrorException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 2361403996911877882L;
+    private final Integer statusCode;
+    private final ErrorDetails errorDetails;
+
+    public ServerErrorException(String message, Integer statusCode, ErrorDetails errorDetails) {
+        super(message);
+        this.statusCode = statusCode;
+        this.errorDetails = errorDetails;
+    }
+
+    public Integer deriveErrorCode() {
+        if (errorDetails != null) {
+            if (errorDetails.getErrorCode() != null) {
+                return errorDetails.getErrorCode();
+            }
+            if (errorDetails.getAuthErrorCodes() != null && !errorDetails.getAuthErrorCodes().isEmpty()) {
+                return errorDetails.getAuthErrorCodes().getFirst();
+            }
+            if (errorDetails.getApiStatusCode() != null) {
+                return errorDetails.getApiStatusCode();
+            }
+        }
+
+        return statusCode;
+    }
+
+    public String deriveErrorMessage() {
+        if (errorDetails != null) {
+            if (errorDetails.getErrorDescription() != null) {
+                return errorDetails.getErrorDescription();
+            }
+            if (errorDetails.getAuthErrorDescription() != null) {
+                return errorDetails.getAuthErrorDescription();
+            }
+            if (errorDetails.getApiErrorMessage() != null) {
+                return errorDetails.getApiErrorMessage();
+            }
+        }
+
+        return getMessage();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/repository/DefaultFutureHearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/repository/DefaultFutureHearingRepository.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckActiveDirectoryException;
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckHmiException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.model.HearingStatusAuditContext;
 import uk.gov.hmcts.reform.hmc.service.HearingStatusAuditService;
 
@@ -89,6 +90,9 @@ public class DefaultFutureHearingRepository implements FutureHearingRepository {
             logDebugHealthCheckActiveDirectoryException(e.getClass().getSimpleName());
             throw new HealthCheckActiveDirectoryException("Resource not found");
         } catch (ApiClientException e) {
+            logDebugHealthCheckActiveDirectoryException(e.getClass().getSimpleName());
+            throw createHealthCheckActiveDirectoryException(e);
+        } catch (ServerErrorException e) {
             logDebugHealthCheckActiveDirectoryException(e.getClass().getSimpleName());
             throw createHealthCheckActiveDirectoryException(e);
         } catch (RetryableException e) {
@@ -180,6 +184,9 @@ public class DefaultFutureHearingRepository implements FutureHearingRepository {
         } catch (ApiClientException e) {
             logDebugHealthCheckHmiException(e);
             throw createHealthCheckHmiException(e);
+        } catch (ServerErrorException e) {
+            logDebugHealthCheckHmiException(e);
+            throw createHealthCheckHmiException(e);
         }
     }
 
@@ -246,6 +253,14 @@ public class DefaultFutureHearingRepository implements FutureHearingRepository {
                                                        exception.getErrorDescription());
     }
 
+    private HealthCheckActiveDirectoryException createHealthCheckActiveDirectoryException(
+        ServerErrorException exception) {
+
+        return new HealthCheckActiveDirectoryException(exception.getMessage(),
+                                                       exception.deriveErrorCode(),
+                                                       exception.deriveErrorMessage());
+    }
+
     private HealthCheckHmiException createHealthCheckHmiException(BadFutureHearingRequestException exception) {
         HealthCheckHmiException healthCheckHmiException;
 
@@ -280,6 +295,12 @@ public class DefaultFutureHearingRepository implements FutureHearingRepository {
         return new HealthCheckHmiException(exception.getMessage(),
                                            exception.getErrorCode(),
                                            exception.getErrorDescription());
+    }
+
+    private HealthCheckHmiException createHealthCheckHmiException(ServerErrorException exception) {
+        return new HealthCheckHmiException(exception.getMessage(),
+                                           exception.deriveErrorCode(),
+                                           exception.deriveErrorMessage());
     }
 
     private Integer getAuthErrorCode(List<Integer> authErrorCodes) {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/MessageProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/MessageProcessor.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.MalformedMessageException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ServiceBusMessageErrorHandler;
 import uk.gov.hmcts.reform.hmc.repository.DefaultFutureHearingRepository;
 
@@ -117,7 +118,7 @@ public class MessageProcessor {
                 pendingRequest.getHearingId().toString(), pendingRequest.getMessageType()
             );
         } catch (ApiClientException | AuthenticationException
-                 | BadFutureHearingRequestException | ResourceNotFoundException ex) {
+                 | BadFutureHearingRequestException | ResourceNotFoundException | ServerErrorException ex) {
             log.debug("Non-retriable exception {}, message {}", ex.getClass().getSimpleName(), ex.getMessage());
             pendingRequestService.handleNonRetriableException(pendingRequest, ex);
             return;

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImpl.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.ApiClientException;
 import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.helper.hmi.HmiHearingResponseMapper;
 import uk.gov.hmcts.reform.hmc.model.HearingStatusAuditContext;
 import uk.gov.hmcts.reform.hmc.model.HmcHearingResponse;
@@ -220,7 +221,9 @@ public class PendingRequestServiceImpl implements PendingRequestService {
             BadFutureHearingRequestException.class, (ex, entity) ->
                 handleBadFutureHearingRequestException((BadFutureHearingRequestException) ex, entity),
             ApiClientException.class, (ex, entity) ->
-                handleApiClientException((ApiClientException) ex, entity)
+                handleApiClientException((ApiClientException) ex, entity),
+            ServerErrorException.class, (ex, entity) ->
+                handleServerErrorException((ServerErrorException) ex, entity)
         );
 
     public void escalatePendingRequests() {
@@ -293,6 +296,10 @@ public class PendingRequestServiceImpl implements PendingRequestService {
         handleException(entity, ex.getErrorCode(), ex.getErrorDescription());
     }
 
+    private static void handleServerErrorException(ServerErrorException ex, HearingEntity entity) {
+        handleException(entity, ex.deriveErrorCode(), ex.deriveErrorMessage());
+    }
+
     private JsonNode extractErrorDetails(Exception exception) {
         if (exception instanceof ResourceNotFoundException resourceNotFoundException) {
             return objectMapper.convertValue(resourceNotFoundException.getMessage(), JsonNode.class);
@@ -305,6 +312,8 @@ public class PendingRequestServiceImpl implements PendingRequestService {
             errorInfo.put("errorCode", apiClientException.getErrorCode());
             errorInfo.put("errorDescription", apiClientException.getErrorDescription());
             return objectMapper.convertValue(errorInfo, JsonNode.class);
+        } else if (exception instanceof ServerErrorException serverErrorException) {
+            return objectMapper.convertValue(serverErrorException.getErrorDetails(), JsonNode.class);
         }
         return objectMapper.convertValue(exception.getMessage(), JsonNode.class);
     }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/client/featurehearing/FutureHearingErrorDecoderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/client/featurehearing/FutureHearingErrorDecoderTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.ApiClientException;
 import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -142,7 +143,7 @@ class FutureHearingErrorDecoderTest {
     }
 
     @Test
-    void shouldThrowAuthenticationExceptionWith500Error() {
+    void shouldThrowServerErrorExceptionWith500Error() {
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
@@ -151,7 +152,7 @@ class FutureHearingErrorDecoderTest {
 
         Exception exception = futureHearingErrorDecoder.decode(METHOD_KEY, response);
 
-        assertThat(exception).isInstanceOf(AuthenticationException.class);
+        assertThat(exception).isInstanceOf(ServerErrorException.class);
         assertEquals(SERVER_ERROR, exception.getMessage());
         List<ILoggingEvent> logsList = listAppender.list;
         assertEquals(1, logsList.size());

--- a/src/test/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.JsonProcessingRuntimeException;
 import uk.gov.hmcts.reform.hmc.errorhandling.MalformedMessageException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ServiceBusMessageErrorHandler;
 import uk.gov.hmcts.reform.hmc.repository.DefaultFutureHearingRepository;
 import uk.gov.hmcts.reform.hmc.service.MessageProcessor;
@@ -282,7 +283,8 @@ class MessageProcessorTest {
             Arguments.of(new BadFutureHearingRequestException("N/A", null)),
             Arguments.of(new AuthenticationException("N/A", null)),
             Arguments.of(new ResourceNotFoundException("N/A")),
-            Arguments.of(new ApiClientException("N/A", null, null))
+            Arguments.of(new ApiClientException("N/A", null, null)),
+            Arguments.of(new ServerErrorException("N/A", null, null))
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/data/JsonDataConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/data/JsonDataConverterTest.java
@@ -5,17 +5,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(MockitoExtension.class)
 class JsonDataConverterTest {
 
-    private static ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     static {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -25,33 +27,39 @@ class JsonDataConverterTest {
     private JsonDataConverter jsonbConverter;
 
     @BeforeEach
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
+    void setup() {
         jsonbConverter = new JsonDataConverter();
     }
 
     @Test
     void convertToDatabaseColumn() throws Exception {
-        assertNull(jsonbConverter.convertToDatabaseColumn(null));
-
         final String jsonString = "{\"key\":\"value\"}";
         assertEquals(jsonString, jsonbConverter.convertToDatabaseColumn(mapper.readTree(jsonString)));
     }
 
     @Test
-    void convertToEntityAttribute() {
-        // Testing null
-        assertNull(jsonbConverter.convertToEntityAttribute(null));
+    void convertToDatabaseColumn_shouldReturnNull() {
+        assertNull(jsonbConverter.convertToDatabaseColumn(null));
+    }
 
-        // Teasing valid non null
+    @Test
+    void convertToEntityAttribute() {
         final JsonNode converted = jsonbConverter.convertToEntityAttribute("{\"key\":\"value\"}");
         assertEquals("value", converted.get("key").asText());
+    }
 
-        try {
-            jsonbConverter.convertToEntityAttribute("hjkdash\"");
-            fail("Expected failure due to incorrect JSON");
-        } catch (Exception e) {
-            assertNotNull(e);
-        }
+    @Test
+    void convertToEntityAttribute_shouldReturnNull() {
+        assertNull(jsonbConverter.convertToEntityAttribute(null));
+    }
+
+    @Test
+    void convertToEntityAttribute_shouldThrowRuntimeException() {
+        RuntimeException exception =
+            assertThrows(RuntimeException.class,
+                         () -> jsonbConverter.convertToEntityAttribute("hjkdash\""),
+                         "Expected failure due to incorrect JSON");
+        assertNotNull(exception);
+        assertEquals("Unable to deserialize to json field", exception.getMessage());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/errorhandling/ServerErrorExceptionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/errorhandling/ServerErrorExceptionTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.hmc.errorhandling;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.hmcts.reform.hmc.client.futurehearing.ErrorDetails;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ServerErrorExceptionTest {
+
+    private static final String EXCEPTION_MESSAGE = "Exception message";
+    private static final String ERROR_DESCRIPTION_ERROR = "Error description";
+    private static final String ERROR_DESCRIPTION_AUTH = "Auth error description";
+    private static final String ERROR_DESCRIPTION_API = "API error description";
+
+    @DisplayName("shouldDeriveErrorMessageAndCode")
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @MethodSource("errorDetailsTestData")
+    void shouldDeriveErrorMessageAndCode(ErrorDetails errorDetails, Integer expectedCode, String expectedMessage) {
+        ServerErrorException exception = new ServerErrorException(EXCEPTION_MESSAGE, 500, errorDetails);
+
+        assertEquals(expectedCode, exception.deriveErrorCode(), "Unexpected error code derived from error details");
+        assertEquals(expectedMessage, exception.deriveErrorMessage(),
+                     "Unexpected error message derived from error details");
+    }
+
+    private static Stream<Arguments> errorDetailsTestData() {
+        ErrorDetails errorDetailsError = new ErrorDetails();
+        errorDetailsError.setErrorCode(100);
+        errorDetailsError.setErrorDescription(ERROR_DESCRIPTION_ERROR);
+
+        ErrorDetails errorDetailsAuth = new ErrorDetails();
+        errorDetailsAuth.setAuthErrorCodes(List.of(200, 300));
+        errorDetailsAuth.setAuthErrorDescription(ERROR_DESCRIPTION_AUTH);
+
+        ErrorDetails errorDetailsAuthNullErrorCodes = new ErrorDetails();
+        errorDetailsAuthNullErrorCodes.setAuthErrorDescription(ERROR_DESCRIPTION_AUTH);
+
+        ErrorDetails errorDetailsAuthEmptyErrorCodes = new ErrorDetails();
+        errorDetailsAuthEmptyErrorCodes.setAuthErrorCodes(Collections.emptyList());
+        errorDetailsAuthEmptyErrorCodes.setAuthErrorDescription(ERROR_DESCRIPTION_AUTH);
+
+        ErrorDetails errorDetailsApi = new ErrorDetails();
+        errorDetailsApi.setApiStatusCode(400);
+        errorDetailsApi.setApiErrorMessage(ERROR_DESCRIPTION_API);
+
+        ErrorDetails errorDetailsAll = new ErrorDetails();
+        errorDetailsAll.setErrorCode(100);
+        errorDetailsAll.setErrorDescription(ERROR_DESCRIPTION_ERROR);
+        errorDetailsAll.setAuthErrorCodes(List.of(200, 300));
+        errorDetailsAll.setAuthErrorDescription(ERROR_DESCRIPTION_AUTH);
+        errorDetailsAll.setApiStatusCode(400);
+        errorDetailsAll.setApiErrorMessage(ERROR_DESCRIPTION_API);
+
+        ErrorDetails errorDetailsEmpty = new ErrorDetails();
+
+        return Stream.of(
+            arguments(named("ErrorDetails with error fields populated",
+                            errorDetailsError),
+                      100,
+                      ERROR_DESCRIPTION_ERROR),
+            arguments(named("ErrorDetails with auth fields populated", errorDetailsAuth), 200, ERROR_DESCRIPTION_AUTH),
+            arguments(named("ErrorDetails with auth fields populated, null auth error codes list",
+                            errorDetailsAuthNullErrorCodes),
+                      500,
+                      ERROR_DESCRIPTION_AUTH),
+            arguments(named("ErrorDetails with auth fields populated, empty auth error codes list",
+                            errorDetailsAuthEmptyErrorCodes),
+                      500,
+                      ERROR_DESCRIPTION_AUTH),
+            arguments(named("ErrorDetails with API fields populated", errorDetailsApi), 400, ERROR_DESCRIPTION_API),
+            arguments(named("ErrorDetails with all fields populated", errorDetailsAll), 100, ERROR_DESCRIPTION_ERROR),
+            arguments(named("ErrorDetails with all fields null ", errorDetailsEmpty), 500, EXCEPTION_MESSAGE),
+            arguments(named("Null ErrorDetails", null), 500, EXCEPTION_MESSAGE)
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/hmc/repository/FutureHearingRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/repository/FutureHearingRepositoryTest.java
@@ -35,6 +35,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckActiveDirectoryException;
 import uk.gov.hmcts.reform.hmc.errorhandling.HealthCheckHmiException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.model.HearingStatusAuditContext;
 import uk.gov.hmcts.reform.hmc.service.HearingStatusAuditServiceImpl;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
@@ -75,6 +76,8 @@ class FutureHearingRepositoryTest {
     private static final String ERROR_DESCRIPTION_AUTH = "Auth error";
     private static final String EXCEPTION_MESSAGE_API_CLIENT = "Api client exception";
     private static final String ERROR_DESCRIPTION_API_CLIENT = "Api client error";
+    private static final String EXCEPTION_MESSAGE_SERVER_ERROR = "Server error exception";
+    private static final String ERROR_DESCRIPTION_SERVER_ERROR = "Server error error";
 
     private static final Logger logger = (Logger) LoggerFactory.getLogger(DefaultFutureHearingRepository.class);
 
@@ -449,6 +452,47 @@ class FutureHearingRepositoryTest {
                       EXCEPTION_MESSAGE_API_CLIENT,
                       500,
                       ERROR_DESCRIPTION_API_CLIENT),
+            arguments(named("ServerErrorException: error details with error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsError(7000, ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      7000,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: error details with auth error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsAuthError(List.of(8000),
+                                                                                 ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      8000,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: error details with api error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsApiError(9000, ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      9000,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: empty error details",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR, 500, new ErrorDetails())
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      500,
+                      EXCEPTION_MESSAGE_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: null error details",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR, 500, null)),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      500,
+                      EXCEPTION_MESSAGE_SERVER_ERROR
+            ),
             arguments(named("RetryableException",
                             new RetryableException(400, "Connection/Read timeout", POST, null, 1L, getTokenRequest)
                       ),
@@ -504,8 +548,60 @@ class FutureHearingRepositoryTest {
                             new ApiClientException(EXCEPTION_MESSAGE_API_CLIENT, 500, ERROR_DESCRIPTION_API_CLIENT)),
                       EXCEPTION_MESSAGE_API_CLIENT,
                       500,
-                      ERROR_DESCRIPTION_API_CLIENT)
+                      ERROR_DESCRIPTION_API_CLIENT
+            ),
+            arguments(named("ServerErrorException: error details with error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsError(600, ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      600,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: error details with auth error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsAuthError(List.of(700),
+                                                                                 ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      700,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: error details with api error fields",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR,
+                                                     500,
+                                                     createErrorDetailsApiError(800, ERROR_DESCRIPTION_SERVER_ERROR))
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      800,
+                      ERROR_DESCRIPTION_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: empty error details",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR, 500, new ErrorDetails())
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      500,
+                      EXCEPTION_MESSAGE_SERVER_ERROR
+            ),
+            arguments(named("ServerErrorException: null error details",
+                            new ServerErrorException(EXCEPTION_MESSAGE_SERVER_ERROR, 500, null)
+                      ),
+                      EXCEPTION_MESSAGE_SERVER_ERROR,
+                      500,
+                      EXCEPTION_MESSAGE_SERVER_ERROR
+            )
         );
+    }
+
+    private static ErrorDetails createErrorDetailsError(Integer errorCode, String errorDescription) {
+        ErrorDetails errorDetails = new ErrorDetails();
+
+        errorDetails.setErrorCode(errorCode);
+        errorDetails.setErrorDescription(errorDescription);
+
+        return errorDetails;
     }
 
     private static ErrorDetails createErrorDetailsAuthError(List<Integer> errorCodes, String errorDescription) {

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/PendingRequestServiceImplTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.hmc.errorhandling.ApiClientException;
 import uk.gov.hmcts.reform.hmc.errorhandling.AuthenticationException;
 import uk.gov.hmcts.reform.hmc.errorhandling.BadFutureHearingRequestException;
 import uk.gov.hmcts.reform.hmc.errorhandling.ResourceNotFoundException;
+import uk.gov.hmcts.reform.hmc.errorhandling.ServerErrorException;
 import uk.gov.hmcts.reform.hmc.helper.hmi.HmiHearingResponseMapper;
 import uk.gov.hmcts.reform.hmc.model.HearingStatusAuditContext;
 import uk.gov.hmcts.reform.hmc.model.HmcHearingResponse;
@@ -87,7 +88,10 @@ class PendingRequestServiceImplTest {
     private MessageSenderToTopicConfiguration messageSenderToTopicConfiguration;
 
     private static final String TEST_EXCEPTION_MESSAGE = "Test Exception";
+    private static final String TEST_AUTH_EXCEPTION_MESSAGE = "Test Auth Exception";
     private static final String TEST_ERROR_DESCRIPTION = "Test Error Description";
+    private static final String TEST_AUTH_ERROR_DESCRIPTION = "Test Auth Error";
+    private static final String TEST_API_ERROR_DESCRIPTION = "Test Api Error";
     private static final String ERROR_MESSAGE =
         "Hearing id: %s with Case reference: %s , Service Code: %s and Error Description: %s updated to status %s";
     private static final String CASE_REF = "1111222233334444";
@@ -523,16 +527,16 @@ class PendingRequestServiceImplTest {
             new BadFutureHearingRequestException(TEST_EXCEPTION_MESSAGE, badFutureHearingRequestErrorDetails);
 
         ErrorDetails authenticationErrorDetailsNonEmpty =
-            TestingUtil.generateAuthErrorDetails("Test Auth Error", INTERNAL_SERVER_ERROR.value());
+            TestingUtil.generateAuthErrorDetails(TEST_AUTH_ERROR_DESCRIPTION, INTERNAL_SERVER_ERROR.value());
         AuthenticationException authenticationExceptionNonEmptyErrorDetails =
-            new AuthenticationException("Test Auth Exception", authenticationErrorDetailsNonEmpty);
+            new AuthenticationException(TEST_AUTH_EXCEPTION_MESSAGE, authenticationErrorDetailsNonEmpty);
 
         ErrorDetails authenticationErrorDetailsEmpty = new ErrorDetails();
         AuthenticationException authenticationExceptionEmptyErrorDetails =
-            new AuthenticationException("Test Auth Exception", authenticationErrorDetailsEmpty);
+            new AuthenticationException(TEST_AUTH_EXCEPTION_MESSAGE, authenticationErrorDetailsEmpty);
 
         AuthenticationException authenticationExceptionErrorDetailsNull =
-            new AuthenticationException("Test Auth Exception");
+            new AuthenticationException(TEST_AUTH_EXCEPTION_MESSAGE);
 
         ResourceNotFoundException resourceNotFoundException = new ResourceNotFoundException(TEST_EXCEPTION_MESSAGE);
 
@@ -541,6 +545,37 @@ class PendingRequestServiceImplTest {
                    "errorDescription", TEST_ERROR_DESCRIPTION);
         ApiClientException apiClientException =
             new ApiClientException(TEST_EXCEPTION_MESSAGE, INTERNAL_SERVER_ERROR.value(), TEST_ERROR_DESCRIPTION);
+
+        ErrorDetails serverErrorErrorDetailsErrorFields =
+            TestingUtil.generateErrorDetails(TEST_ERROR_DESCRIPTION, 9999);
+        ServerErrorException serverErrorExceptionErrorFields =
+            new ServerErrorException(TEST_EXCEPTION_MESSAGE,
+                                     INTERNAL_SERVER_ERROR.value(),
+                                     serverErrorErrorDetailsErrorFields);
+
+        ErrorDetails serverErrorErrorDetailsAuthErrorFields =
+            TestingUtil.generateAuthErrorDetails(TEST_AUTH_ERROR_DESCRIPTION, 1000);
+        ServerErrorException serverErrorExceptionAuthErrorFields =
+            new ServerErrorException(TEST_EXCEPTION_MESSAGE,
+                                     INTERNAL_SERVER_ERROR.value(),
+                                     serverErrorErrorDetailsAuthErrorFields);
+
+        ErrorDetails serverErrorErrorDetailsApiErrorFields = new ErrorDetails();
+        serverErrorErrorDetailsApiErrorFields.setApiStatusCode(999);
+        serverErrorErrorDetailsApiErrorFields.setApiErrorMessage(TEST_API_ERROR_DESCRIPTION);
+        ServerErrorException serverErrorExceptionApiErrorFields =
+            new ServerErrorException(TEST_EXCEPTION_MESSAGE,
+                                     INTERNAL_SERVER_ERROR.value(),
+                                     serverErrorErrorDetailsApiErrorFields);
+
+        ErrorDetails serverErrorErrorDetailsEmpty = new ErrorDetails();
+        ServerErrorException serverErrorExceptionEmptyErrorDetails =
+            new ServerErrorException(TEST_EXCEPTION_MESSAGE,
+                                     INTERNAL_SERVER_ERROR.value(),
+                                     serverErrorErrorDetailsEmpty);
+
+        ServerErrorException serverErrorExceptionNullErrorDetails =
+            new ServerErrorException(TEST_EXCEPTION_MESSAGE, INTERNAL_SERVER_ERROR.value(), null);
 
         return Stream.of(
             arguments(named("BadFutureHearingRequestException", badFutureHearingRequestException),
@@ -551,7 +586,7 @@ class PendingRequestServiceImplTest {
             arguments(named("AuthenticationException - non-empty ErrorDetails",
                             authenticationExceptionNonEmptyErrorDetails),
                       authenticationErrorDetailsNonEmpty,
-                      "Test Auth Error",
+                      TEST_AUTH_ERROR_DESCRIPTION,
                       INTERNAL_SERVER_ERROR.value()
             ),
             arguments(named("AuthenticationException - empty ErrorDetails", authenticationExceptionEmptyErrorDetails),
@@ -572,6 +607,33 @@ class PendingRequestServiceImplTest {
             arguments(named("ApiClientException", apiClientException),
                       apiClientErrorDetails,
                       TEST_ERROR_DESCRIPTION,
+                      INTERNAL_SERVER_ERROR.value()
+            ),
+            arguments(named("ServerErrorException - ErrorDetails error fields", serverErrorExceptionErrorFields),
+                      serverErrorErrorDetailsErrorFields,
+                      TEST_ERROR_DESCRIPTION,
+                      9999
+            ),
+            arguments(named("ServerErrorException - ErrorDetails auth error fields",
+                            serverErrorExceptionAuthErrorFields),
+                      serverErrorErrorDetailsAuthErrorFields,
+                      TEST_AUTH_ERROR_DESCRIPTION,
+                      1000
+            ),
+            arguments(named("ServerErrorException - ErrorDetails api error fields",
+                            serverErrorExceptionApiErrorFields),
+                      serverErrorErrorDetailsApiErrorFields,
+                      TEST_API_ERROR_DESCRIPTION,
+                      999
+            ),
+            arguments(named("ServerErrorException - empty ErrorDetails", serverErrorExceptionEmptyErrorDetails),
+                      serverErrorErrorDetailsEmpty,
+                      TEST_EXCEPTION_MESSAGE,
+                      INTERNAL_SERVER_ERROR.value()
+            ),
+            arguments(named("ServerErrorException - null ErrorDetails", serverErrorExceptionNullErrorDetails),
+                      null,
+                      TEST_EXCEPTION_MESSAGE,
                       INTERNAL_SERVER_ERROR.value()
             )
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1041](https://tools.hmcts.net/jira/browse/HMAN-1041)


### Change description ###
Added new ServerErrorException class.

Changed FutureHearingErrorDecoder to return a ServerErrorException instead of an AuthenticationException when processing a non-400, 401 or 404 error response.

Changed DefaultFutureHearingRepository privateHealthCheck() and getPrivateHealthCheck() methods to handle ServerErrorExceptions.

Added an exception handler for ServerErrorExceptions to PendingRequestServiceImpl. Also changed extractErrorDetails() method in that class to support extraction of error details from ServerErrorExceptions.

Added ServerErrorException to non-retriable exceptions catch block in MessageProcesser processPendingRequest() method.

Updated tests in line with changes.

Updated JsonDataConverterTest to address Sonar issues and separate tests out into separate methods.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
